### PR TITLE
Remove redundant server console.log

### DIFF
--- a/middleware/logger.js
+++ b/middleware/logger.js
@@ -23,7 +23,6 @@ const logEvents = async (message, logFileName) => {
 
 const logger = (req, res, next) => {
   logEvents(`${req.method}\t${req.url}\t${req.headers.origin}`, "reqLog.log");
-  console.log(`${req.method} ${req.path}`);
   next();
 };
 


### PR DESCRIPTION
Already using morgan package for this, which provides more details, so basically this console.log just duplicates the same behaviour and is not as good