### PR TITLE
chore(dev): add env templates and fix local dev port alignment

### DIFF
--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -1,1 +1,3 @@
 Your job is to create a PR with a descriptive title, always use the GitHub CLI. If you haven't already made a commit, make one first.
+
+PR title format is defined in [AGENTS.md](../../AGENTS.md): `type(area): short imperative summary`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent instructions
+
+Guidance for AI agents and contributors working on this repo.
+
+## PR and commit titles
+
+Format: `type(area): short imperative summary`
+
+Examples:
+
+- `chore(dev): add env templates and align dev ports`
+- `fix(auth): include user id in getUser JWT payload`
+- `fix(charts): repair earnings-by-clients dashboard chart`
+- `docs(revival): update phase 0 progress`
+
+**Types:** `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`
+
+**Areas:** `dev`, `auth`, `charts`, `projects`, `clients`, `server`, `client`, `revival`, `ci`
+
+Use the same format for commits when possible. The PR title should match the branch's main change.
+
+## Revival work
+
+Follow phases in [docs/REVIVAL-PLAN.md](docs/REVIVAL-PLAN.md). Prefer one logical phase step per branch when practical.
+
+## Local development
+
+See [README.md](README.md#local-development). Server env: copy `server/.env.example` to `.env.server` at the repo root.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,58 @@
 
 App for tracking money made per month, per year and per client
 
+## Local development
+
+### Prerequisites
+
+- **Node.js** 18+ (see `engines` in root and `client/package.json`)
+- **MongoDB** running locally (default URI: `mongodb://127.0.0.1:27017`)
+
+### Setup
+
+1. Install dependencies (root tooling, client, and server):
+
+   ```bash
+   npm install
+   npm install --prefix client
+   npm install --prefix server
+   ```
+
+2. Create server environment file from the template:
+
+   ```bash
+   cp server/.env.example .env.server
+   ```
+
+   Edit `.env.server` if your MongoDB host or credentials differ. The default `PORT` is **6000**, which matches the CRA dev proxy in `client/package.json`.
+
+   If you have an existing `.env.server` with `PORT=5000`, update it to `6000` (or change the client proxy to match).
+
+3. Start client and server together:
+
+   ```bash
+   npm run dev
+   ```
+
+   - Frontend: [http://localhost:3000](http://localhost:3000)
+   - API: [http://localhost:6000/api/v1](http://localhost:6000/api/v1)
+
+### Tests
+
+```bash
+# Server integration tests (requires MongoDB; uses DB_TEST from .env.server)
+npm run server:test
+
+# Client unit tests
+npm run client:test
+```
+
+### Optional client env
+
+See `client/.env.example`. For most setups the tracked `client/.env.development` is enough. Copy to `.env.development.local` only if you need overrides.
+
+---
+
 CURRENT:
 
 - Search field on Projects page

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,8 @@
+# Optional client env vars for local development.
+# Copy to `.env.development.local` to override CRA defaults without editing tracked files:
+#   cp client/.env.example client/.env.development.local
+#
+# The tracked `.env.development` already sets DANGEROUSLY_DISABLE_HOST_CHECK for offline/VPN setups.
+
+# Avoid "allowedHosts[0] should be a non-empty string" when hostname resolution fails.
+# DANGEROUSLY_DISABLE_HOST_CHECK=true

--- a/client/package.json
+++ b/client/package.json
@@ -77,7 +77,7 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:5000",
+  "proxy": "http://localhost:6000",
   "msw": {
     "workerDirectory": "public"
   }

--- a/docs/REVIVAL-PLAN.md
+++ b/docs/REVIVAL-PLAN.md
@@ -140,7 +140,7 @@ flowchart TD
 
 | Phase | Goal | Status |
 |-------|------|--------|
-| **0** | Make it run, fix critical bugs, quick wins | Not started |
+| **0** | Make it run, fix critical bugs, quick wins | In progress |
 | **1** | CRA → Vite, server TS, shared types, CI | Not started |
 | **2** | Complete core product features from README | Not started |
 | **3** | Optional: Next.js / TanStack Start / NestJS | Deferred |
@@ -155,9 +155,9 @@ flowchart TD
 
 ### 0.1 Environment & local run
 
-- [ ] Add `server/.env.example` (DB URI, `ACCESS_TOKEN_SECRET`, `JWT_EXPIRES_IN`, `PORT`)
-- [ ] Add `client/.env.example` if needed (proxy / API base URL)
-- [ ] Document local setup in README (MongoDB, `npm run dev`, test DB)
+- [x] Add `server/.env.example` (DB URI, `ACCESS_TOKEN_SECRET`, `JWT_EXPIRES_IN`, `PORT`)
+- [x] Add `client/.env.example` if needed (proxy / API base URL)
+- [x] Document local setup in README (MongoDB, `npm run dev`, test DB)
 - [ ] Verify `npm run dev` starts client + server without errors
 
 ### 0.2 Critical bug fixes
@@ -192,12 +192,14 @@ flowchart TD
 - [ ] README "CURRENT" section updated to reflect fixed items
 - [ ] Phase 0 PR merged / tagged
 
-**Phase 0 status:** `Not started` | `In progress` | `Complete`
+**Phase 0 status:** `In progress`
 
 **Notes:**
 
 ```
-(add progress notes, blockers, decisions here)
+Phase 0.1 (branch revival/phase-0-1-local-dev-setup): env templates, dotenv path fix,
+CRA proxy aligned to server PORT 6000, README local setup section.
+Server startup on PORT=6000 verified locally; full `npm run dev` smoke test still pending.
 ```
 
 ---
@@ -416,6 +418,7 @@ Features not in scope for Phases 0–2 but worth tracking:
 
 | Date | Phase | What was done |
 |------|-------|---------------|
+| 2026-07-06 | 0.1 | Env templates, local setup docs, proxy/port alignment |
 | 2026-07-06 | — | Revival plan document created |
 
 ---

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,16 @@
+# Copy to the repo root as `.env.server` before running the server locally:
+#   cp server/.env.example .env.server
+#
+# Required for local development and server tests.
+
+# MongoDB connection strings
+DB_MAIN=mongodb://127.0.0.1:27017/freelancer
+DB_DEVELOPMENT=mongodb://127.0.0.1:27017/freelancer_dev
+DB_TEST=mongodb://127.0.0.1:27017/freelancer_test
+
+# JWT (use a long random string in real environments)
+ACCESS_TOKEN_SECRET=change-me-to-a-long-random-string
+JWT_EXPIRES_IN=7d
+
+# Express listen port — must match the CRA dev proxy in client/package.json (default 6000)
+PORT=6000

--- a/server/app.js
+++ b/server/app.js
@@ -14,7 +14,7 @@ const corsOptions = require("./config/corsOptions");
 const { clientRouter, projectRouter, userRouter } = require("./resources");
 
 if (process.env.NODE_ENV !== "production") {
-  dotenv.config({ path: ".env.server" });
+  dotenv.config({ path: path.join(__dirname, "../.env.server") });
 }
 
 // Connect to mongo DB

--- a/server/test/test-helpers.js
+++ b/server/test/test-helpers.js
@@ -2,7 +2,7 @@ const path = require("path");
 const mongoose = require("mongoose");
 const jwt = require("jsonwebtoken");
 
-require("dotenv").config({ path: path.join(__dirname, "../.env.server") });
+require("dotenv").config({ path: path.join(__dirname, "../../.env.server") });
 
 const Project = require("../resources/project/project.model");
 const Client = require("../resources/client/client.model");


### PR DESCRIPTION
## Summary

Implements **Phase 0.1 — Environment & local run** from [REVIVAL-PLAN.md](docs/REVIVAL-PLAN.md): makes local development reproducible and fixes dev networking mismatches.

- Add `server/.env.example` (MongoDB URIs, JWT secrets, `PORT=6000`) and optional `client/.env.example`
- Document local setup in README (prerequisites, install steps, `npm run dev`, tests)
- Load `.env.server` from repo root via `path.join(__dirname, …)` in `server/app.js` and `server/test/test-helpers.js` (cwd-independent; fixes tests pointing at wrong path)
- Align CRA dev proxy (`client/package.json`) from port **5000** → **6000** to match server default `PORT`
- Update revival plan progress (Phase 0 → in progress, 0.1 checklist)

## Test plan

- [ ] Copy env template: `cp server/.env.example .env.server`
- [ ] Ensure MongoDB is running locally
- [ ] If upgrading an existing setup, set `PORT=6000` in `.env.server` (or revert proxy to match your port)
- [ ] Run `npm run dev` — client on :3000, server on :6000, no proxy/port errors
- [ ] Smoke test: login → dashboard loads → projects/clients pages fetch data
- [ ] Run `npm run server:test` with `DB_TEST` configured